### PR TITLE
fix server descriptor znode recreation

### DIFF
--- a/src/main/java/com/wepay/zktools/clustermgr/internal/ClusterManagerImpl.java
+++ b/src/main/java/com/wepay/zktools/clustermgr/internal/ClusterManagerImpl.java
@@ -286,7 +286,10 @@ public class ClusterManagerImpl implements ClusterManager {
                             ServerDescriptor descriptor =
                                 new ServerDescriptor(managedServerInfo.serverId, server.endpoint(), server.getPreferredPartitions());
 
-                            createServerZNode(s, descriptor);
+                            ZNode znode = createServerZNode(s, descriptor);
+
+                            // Update ManagedServerInfo with the new znode.
+                            managedServers.put(server, new ManagedServerInfo(descriptor.serverId, znode));
                         }
                     }
                 } catch (Exception ex) {


### PR DESCRIPTION
When `ClusterManager` recreates a server descriptor znode, it didn't update `managedServerInfo` in `managedServers` to point to the new znode.