### PR TITLE
Manage Partition Assignment Policy taking into account preferred partitons.

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -1,3 +1,3 @@
 group=com.wepay.zktools
 sourceCompatibility=1.8
-version=0.5.0
+version=0.6.0

--- a/src/main/java/com/wepay/zktools/clustermgr/ManagedServer.java
+++ b/src/main/java/com/wepay/zktools/clustermgr/ManagedServer.java
@@ -1,6 +1,5 @@
 package com.wepay.zktools.clustermgr;
 
-import java.util.Collections;
 import java.util.List;
 
 /**
@@ -16,7 +15,5 @@ public interface ManagedServer {
 
     void setPartitions(List<PartitionInfo> partitionInfos);
 
-    default List<Integer> getPreferredPartitions() {
-        return Collections.emptyList();
-    }
+    List<Integer> getPreferredPartitions();
 }

--- a/src/main/java/com/wepay/zktools/clustermgr/ManagedServer.java
+++ b/src/main/java/com/wepay/zktools/clustermgr/ManagedServer.java
@@ -1,5 +1,6 @@
 package com.wepay.zktools.clustermgr;
 
+import java.util.Collections;
 import java.util.List;
 
 /**
@@ -15,5 +16,7 @@ public interface ManagedServer {
 
     void setPartitions(List<PartitionInfo> partitionInfos);
 
-    List<Integer> getPreferredPartitions();
+    default List<Integer> getPreferredPartitions() {
+        return Collections.emptyList();
+    }
 }

--- a/src/main/java/com/wepay/zktools/clustermgr/internal/ClusterManagerImpl.java
+++ b/src/main/java/com/wepay/zktools/clustermgr/internal/ClusterManagerImpl.java
@@ -245,11 +245,17 @@ public class ClusterManagerImpl implements ClusterManager {
                             Cluster currentCluster = clusterState.get();
                             int version = currentCluster.version;
                             PartitionAssignment assignment = currentCluster.partitionAssignment;
-                            HashMap<Integer, ServerDescriptor> membership =
-                                new HashMap<>(currentCluster.serverMembership);
 
-                            // Update the new server descriptor of this server.
-                            membership.put(serverId, descriptor);
+                            // Create new membership map
+                            HashMap<Integer, ServerDescriptor> membership = new HashMap<>();
+                            for (ServerDescriptor serverDescriptor : currentCluster.serverMembership.values()) {
+                                if (serverDescriptor.serverId == serverId) {
+                                    // Update the new server descriptor of this server.
+                                    membership.put(serverId, descriptor);
+                                } else {
+                                    membership.put(serverDescriptor.serverId, serverDescriptor);
+                                }
+                            }
 
                             // retry if the partitionAssignment failed to update. (May happen because of
                             // race-condition.)

--- a/src/main/java/com/wepay/zktools/clustermgr/internal/DynamicPartitionAssignmentPolicy.java
+++ b/src/main/java/com/wepay/zktools/clustermgr/internal/DynamicPartitionAssignmentPolicy.java
@@ -10,6 +10,8 @@ import java.util.HashMap;
 import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
+import java.util.function.Function;
+import java.util.stream.Collectors;
 
 /**
  * An implementation of partition assignment policy. Each partition is assigned to exactly one server.
@@ -32,47 +34,94 @@ public class DynamicPartitionAssignmentPolicy implements PartitionAssignmentPoli
         int numServers = serverDescriptors.size();
 
         if (numServers > 0) {
-            ArrayList<PartitionInfo> unassigned = new ArrayList<>();
+            // store partitionInfo of all the partitions.
+            Map<Integer, PartitionInfo> unassignedPartitionInfoMap = new HashMap<>();
+            Map<Integer, Integer> partitionToExistingServerMap = new HashMap<>();
 
             // Add new partitions to the unassigned set
             for (int id = oldAssignment.numPartitions; id < numPartitions; id++) {
-                unassigned.add(new PartitionInfo(id, 0));
+                PartitionInfo partitionInfo = new PartitionInfo(id, 0);
+                unassignedPartitionInfoMap.put(id, partitionInfo);
+                partitionToExistingServerMap.put(id, -1);
             }
-            // Unassign partitions from lost servers
+
+            // reassign partitions of all servers
             for (Integer serverId : oldAssignment.serverIds()) {
-                if (!serverDescriptors.containsKey(serverId)) {
-                    unassigned.addAll(oldAssignment.partitionsFor(serverId));
-                }
+                // store partitionInfo of all the old partitions.
+                Map<Integer, PartitionInfo> serverPartitionInfoMap =
+                    oldAssignment.partitionsFor(serverId)
+                        .stream()
+                        .collect(Collectors.toMap(partitionInfo -> partitionInfo.partitionId, Function.identity()));
+                unassignedPartitionInfoMap.putAll(serverPartitionInfoMap);
+                serverPartitionInfoMap.forEach((partitionId, partitionInfo) -> { partitionToExistingServerMap.put(partitionId,
+                    serverId); });
             }
 
             HashMap<Integer, List<PartitionInfo>> newAssignment = new HashMap<>();
-
             int numPartitionsToAssign = numPartitions;
             int minNumPartitionsPerServer = numPartitionsToAssign / numServers;
             int remainingPartitions = numPartitionsToAssign % numServers;
 
+            // Inherit the currently assigned preferred partitions as many as possible
+            for (Map.Entry<Integer, ServerDescriptor> serverEntry : serverDescriptors.entrySet()) {
+                List<PartitionInfo> partitions = new ArrayList<>(minNumPartitionsPerServer + (remainingPartitions > 0 ? 1 : 0));
+                newAssignment.put(serverEntry.getKey(), partitions);
+
+                // Handle preferred partitions.
+                // Recreate partition info with the new generation number if the partition is being moved to a new
+                // server.
+                for (Integer partitionId : serverEntry.getValue().partitions) {
+                    PartitionInfo oldInfo = unassignedPartitionInfoMap.get(partitionId);
+                    if (oldInfo != null) {
+                        Integer oldServerId = partitionToExistingServerMap.get(partitionId);
+                        if (partitions.size() < minNumPartitionsPerServer) {
+                            if (serverEntry.getKey().equals(oldServerId)) {
+                                partitions.add(oldInfo);
+                            } else {
+                                partitions.add(new PartitionInfo(partitionId, oldInfo.generation + 1));
+                            }
+                            numPartitionsToAssign--;
+                            unassignedPartitionInfoMap.remove(partitionId);
+                        } else if (partitions.size() == minNumPartitionsPerServer && remainingPartitions > 0) {
+                            if (serverEntry.getKey().equals(oldServerId)) {
+                                partitions.add(oldInfo);
+                            } else {
+                                partitions.add(new PartitionInfo(partitionId, oldInfo.generation + 1));
+                            }
+                            numPartitionsToAssign--;
+                            unassignedPartitionInfoMap.remove(partitionId);
+                            remainingPartitions--;
+                        }
+                    }
+                }
+            }
+
             // Inherit the currently assigned partitions as many as possible
             for (Integer serverId : serverDescriptors.keySet()) {
-                List<PartitionInfo> partitions = new ArrayList<>(minNumPartitionsPerServer + (remainingPartitions > 0 ? 1 : 0));
-                newAssignment.put(serverId, partitions);
+                List<PartitionInfo> partitions = newAssignment.get(serverId);
+                // Handle rest of the partitions.
                 for (PartitionInfo info : oldAssignment.partitionsFor(serverId)) {
-                    // Move partition infos to new list of partitions up to maxNumPartitionsPerServer
-                    // Excess partitions will be unassigned
-                    if (partitions.size() < minNumPartitionsPerServer) {
-                        partitions.add(info);
-                        numPartitionsToAssign--;
-                    } else if (partitions.size() == minNumPartitionsPerServer && remainingPartitions > 0) {
-                        partitions.add(info);
-                        numPartitionsToAssign--;
-                        remainingPartitions--;
-                    } else {
-                        unassigned.add(info);
+                    Integer partitionId = info.partitionId;
+                    if (unassignedPartitionInfoMap.get(partitionId) != null) {
+                        // Move partition infos to new list of partitions up to maxNumPartitionsPerServer
+                        if (partitions.size() < minNumPartitionsPerServer) {
+                            partitions.add(info);
+                            numPartitionsToAssign--;
+                            unassignedPartitionInfoMap.remove(partitionId);
+                        } else if (partitions.size() == minNumPartitionsPerServer && remainingPartitions > 0) {
+                            partitions.add(info);
+                            numPartitionsToAssign--;
+                            unassignedPartitionInfoMap.remove(partitionId);
+                            remainingPartitions--;
+                        } else {
+                            break;
+                        }
                     }
                 }
             }
 
             // Assign unassigned partitions. Partition infos are recreated with new generation numbers.
-            Iterator<PartitionInfo> iterator = unassigned.iterator();
+            Iterator<PartitionInfo> iterator = unassignedPartitionInfoMap.values().iterator();
             for (Integer serverId : serverDescriptors.keySet()) {
                 List<PartitionInfo> partitions = newAssignment.get(serverId);
                 while (iterator.hasNext()) {
@@ -106,5 +155,4 @@ public class DynamicPartitionAssignmentPolicy implements PartitionAssignmentPoli
             return new PartitionAssignment(cversion, numPartitions, Collections.emptyMap());
         }
     }
-
 }

--- a/src/main/java/com/wepay/zktools/clustermgr/internal/DynamicPartitionAssignmentPolicy.java
+++ b/src/main/java/com/wepay/zktools/clustermgr/internal/DynamicPartitionAssignmentPolicy.java
@@ -47,14 +47,11 @@ public class DynamicPartitionAssignmentPolicy implements PartitionAssignmentPoli
 
             // reassign partitions of all servers
             for (Integer serverId : oldAssignment.serverIds()) {
-                // store partitionInfo of all the old partitions.
-                Map<Integer, PartitionInfo> serverPartitionInfoMap =
-                    oldAssignment.partitionsFor(serverId)
-                        .stream()
-                        .collect(Collectors.toMap(partitionInfo -> partitionInfo.partitionId, Function.identity()));
-                unassignedPartitionInfoMap.putAll(serverPartitionInfoMap);
-                serverPartitionInfoMap.forEach((partitionId, partitionInfo) -> { partitionToExistingServerMap.put(partitionId,
-                    serverId); });
+                // store partition assignment of all old partitions.
+                oldAssignment.partitionsFor(serverId).forEach(partitionInfo -> {
+                    unassignedPartitionInfoMap.put(partitionInfo.partitionId, partitionInfo);
+                    partitionToExistingServerMap.put(partitionInfo.partitionId, serverId);
+                });
             }
 
             HashMap<Integer, List<PartitionInfo>> newAssignment = new HashMap<>();

--- a/src/main/java/com/wepay/zktools/clustermgr/internal/DynamicPartitionAssignmentPolicy.java
+++ b/src/main/java/com/wepay/zktools/clustermgr/internal/DynamicPartitionAssignmentPolicy.java
@@ -10,8 +10,6 @@ import java.util.HashMap;
 import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
-import java.util.function.Function;
-import java.util.stream.Collectors;
 
 /**
  * An implementation of partition assignment policy. Each partition is assigned to exactly one server.

--- a/src/main/java/com/wepay/zktools/clustermgr/internal/PartitionAssignment.java
+++ b/src/main/java/com/wepay/zktools/clustermgr/internal/PartitionAssignment.java
@@ -65,7 +65,7 @@ public class PartitionAssignment {
 
     @Override
     public int hashCode() {
-        return Objects.hash(cversion, numEndpoints, numEndpoints, assignment);
+        return Objects.hash(cversion, numPartitions, numEndpoints, assignment);
     }
 
     @Override

--- a/src/test/java/com/wepay/zktools/clustermgr/internal/DynamicPartitionAssignmentPolicyTest.java
+++ b/src/test/java/com/wepay/zktools/clustermgr/internal/DynamicPartitionAssignmentPolicyTest.java
@@ -64,49 +64,72 @@ public class DynamicPartitionAssignmentPolicyTest {
     }
 
     @Test
-    public void testPreferredPartitions() {
+    public void testPreferredPartitions1() {
         DynamicPartitionAssignmentPolicy policy = new DynamicPartitionAssignmentPolicy();
 
         Map<Integer, List<PartitionInfo>> assignmentMap = new HashMap<>();
-        assignmentMap.put(1, Arrays.asList(new PartitionInfo(0, 0)));
-        assignmentMap.put(2, Arrays.asList(new PartitionInfo(1, 0), new PartitionInfo(2, 0)));
+        assignmentMap.put(1, Arrays.asList(new PartitionInfo(0, 0),
+                                            new PartitionInfo(1, 0),
+                                            new PartitionInfo(2, 0),
+                                            new PartitionInfo(3, 0)));
 
-        PartitionAssignment assignment = new PartitionAssignment(0, 3, assignmentMap);
-
+        PartitionAssignment assignment = new PartitionAssignment(0, 4, assignmentMap);
         Map<Integer, ServerDescriptor> servers = new HashMap<>();
         servers.put(1, new ServerDescriptor(1, new Endpoint("host0", 6000), Collections.emptyList()));
-        servers.put(2, new ServerDescriptor(2, new Endpoint("host1", 6000), Collections.emptyList()));
 
-        assignment = policy.update(1, assignment, 3, servers);
-
+        assignment = policy.update(1, assignment, 4, servers);
         /** Verify partition assignment of the servers.
-         *  Server 1 ====> P0
-         *  Server 2 ====> P1, P2
+         *  Server 1: Partitions Assigned ====> P0, P1, P2, P3;  Preferred Partitions ====> -
          */
-        assertEquals(2, assignment.numEndpoints);
-        assertEquals(1, assignment.partitionsFor(1).size());
+        assertEquals(1, assignment.numEndpoints);
+        assertEquals(4, assignment.partitionsFor(1).size());
         assertTrue(assignment.partitionsFor(1).contains(new PartitionInfo(0, 0)));
-        assertEquals(2, assignment.partitionsFor(2).size());
-        assertTrue(assignment.partitionsFor(2).contains(new PartitionInfo(1, 0)));
-        assertTrue(assignment.partitionsFor(2).contains(new PartitionInfo(2, 0)));
+        assertTrue(assignment.partitionsFor(1).contains(new PartitionInfo(1, 0)));
+        assertTrue(assignment.partitionsFor(1).contains(new PartitionInfo(2, 0)));
+        assertTrue(assignment.partitionsFor(1).contains(new PartitionInfo(3, 0)));
 
-        // Move P2 from Server 2 to Server 1 by making P2 as preferred partition of Server 1.
-        servers.put(1, new ServerDescriptor(1, new Endpoint("host0", 6000), Collections.singletonList(2)));
-        assignment = policy.update(2, assignment, 3, servers);
+        // Make P2, P3 as preferred partition to server 1
+        servers.put(1, new ServerDescriptor(1, new Endpoint("host0", 6000), Arrays.asList(2, 3)));
+        assignment = policy.update(2, assignment, 4, servers);
+        /** Verify partition assignment of the servers. [Note: no change in assignment]
+         *  Server 1: Partitions Assigned ====> P0, P1, P2, P3;  Preferred Partitions ====> P2, P3
+         */
+        assertEquals(1, assignment.numEndpoints);
+        assertEquals(4, assignment.partitionsFor(1).size());
+        assertTrue(assignment.partitionsFor(1).contains(new PartitionInfo(0, 0)));
+        assertTrue(assignment.partitionsFor(1).contains(new PartitionInfo(1, 0)));
+        assertTrue(assignment.partitionsFor(1).contains(new PartitionInfo(2, 0)));
+        assertTrue(assignment.partitionsFor(1).contains(new PartitionInfo(3, 0)));
 
-        /** Verify partition assignment of the servers:
-         *  Server 1 ====> P0, P2
-         *  Server 2 ====> P1
+        // Add server 2
+        servers.put(2, new ServerDescriptor(2, new Endpoint("host1", 6000), Collections.emptyList()));
+        assignment = policy.update(3, assignment, 4, servers);
+        /** Verify partition assignment of the servers. [Note: Change in assignment]
+         *  Server 1: Partitions Assigned ====> P2, P3;  Preferred Partitions ====> P2, P3
+         *  Server 2: Partitions Assigned ====> P0, P1;  Preferred Partitions ====> -
          */
         assertEquals(2, assignment.numEndpoints);
         assertEquals(2, assignment.partitionsFor(1).size());
-        assertTrue(assignment.partitionsFor(1).contains(new PartitionInfo(0, 0)));
-        assertTrue(assignment.partitionsFor(1).contains(new PartitionInfo(2, 1)));
-        assertEquals(1, assignment.partitionsFor(2).size());
-        assertTrue(assignment.partitionsFor(2).contains(new PartitionInfo(1, 0)));
+        assertTrue(assignment.partitionsFor(1).contains(new PartitionInfo(2, 0)));
+        assertTrue(assignment.partitionsFor(1).contains(new PartitionInfo(3, 0)));
+        assertEquals(2, assignment.partitionsFor(2).size());
+        assertTrue(assignment.partitionsFor(2).contains(new PartitionInfo(0, 1)));
+        assertTrue(assignment.partitionsFor(2).contains(new PartitionInfo(1, 1)));
 
-        // Move P2 from Server 1 to Server 2 by making P2 as preferred partition for Server 2.
+        // Make P2 as preferred partition to Server 2
         servers.put(2, new ServerDescriptor(2, new Endpoint("host1", 6000), Collections.singletonList(2)));
+        assignment = policy.update(4, assignment, 4, servers);
+        /** Verify partition assignment of the servers. [Note: No change in assignment]
+         *  Server 1: Partitions Assigned ====> P2, P3;  Preferred Partitions ====> P2, P3
+         *  Server 2: Partitions Assigned ====> P0, P1;  Preferred Partitions ====> P2
+         */
+        assertEquals(2, assignment.numEndpoints);
+        assertEquals(2, assignment.partitionsFor(1).size());
+        assertTrue(assignment.partitionsFor(1).contains(new PartitionInfo(2, 0)));
+        assertTrue(assignment.partitionsFor(1).contains(new PartitionInfo(3, 0)));
+        assertEquals(2, assignment.partitionsFor(2).size());
+        assertTrue(assignment.partitionsFor(2).contains(new PartitionInfo(0, 1)));
+        assertTrue(assignment.partitionsFor(2).contains(new PartitionInfo(1, 1)));
 
         /**
          *  Note: At this point P2 is assigned as preferred partition for both Server 1 and Server 2.
@@ -115,19 +138,18 @@ public class DynamicPartitionAssignmentPolicyTest {
          *  Otherwise, even after specifying P2 as a preferred partition of Server 2, P2 will get assigned to Server
          *  1 as we assign the partitions to the servers in sequential order.
          */
-        servers.put(1, new ServerDescriptor(1, new Endpoint("host0", 6000), Collections.emptyList()));
-        assignment = policy.update(3, assignment, 3, servers);
-
-        /** Verify partition assignment of the servers:
-         *  Server 1 ====> P0
-         *  Server 2 ====> P1, P2
+        // Un-assign P2 from server 1
+        servers.put(1, new ServerDescriptor(1, new Endpoint("host0", 6000), Arrays.asList(3)));
+        assignment = policy.update(5, assignment, 4, servers);
+        /** Verify partition assignment of the servers.
+         *  Server 1: Partitions Assigned ====> (P0 or P1), P3;  Preferred Partitions ====> P3
+         *  Server 2: Partitions Assigned ====> (P0 or P1), P2;  Preferred Partitions ====> P2
          */
         assertEquals(2, assignment.numEndpoints);
-        assertEquals(1, assignment.partitionsFor(1).size());
-        assertTrue(assignment.partitionsFor(1).contains(new PartitionInfo(0, 0)));
+        assertEquals(2, assignment.partitionsFor(1).size());
+        assertTrue(assignment.partitionsFor(1).contains(new PartitionInfo(3, 0)));
         assertEquals(2, assignment.partitionsFor(2).size());
-        assertTrue(assignment.partitionsFor(2).contains(new PartitionInfo(1, 0)));
-        assertTrue(assignment.partitionsFor(2).contains(new PartitionInfo(2, 2)));
+        assertTrue(assignment.partitionsFor(2).contains(new PartitionInfo(2, 1)));
     }
 
 }

--- a/src/test/java/com/wepay/zktools/clustermgr/internal/DynamicPartitionAssignmentPolicyTest.java
+++ b/src/test/java/com/wepay/zktools/clustermgr/internal/DynamicPartitionAssignmentPolicyTest.java
@@ -63,4 +63,71 @@ public class DynamicPartitionAssignmentPolicyTest {
         assertTrue(assignment.serverIds().isEmpty());
     }
 
+    @Test
+    public void testPreferredPartitions() {
+        DynamicPartitionAssignmentPolicy policy = new DynamicPartitionAssignmentPolicy();
+
+        Map<Integer, List<PartitionInfo>> assignmentMap = new HashMap<>();
+        assignmentMap.put(1, Arrays.asList(new PartitionInfo(0, 0)));
+        assignmentMap.put(2, Arrays.asList(new PartitionInfo(1, 0), new PartitionInfo(2, 0)));
+
+        PartitionAssignment assignment = new PartitionAssignment(0, 3, assignmentMap);
+
+        Map<Integer, ServerDescriptor> servers = new HashMap<>();
+        servers.put(1, new ServerDescriptor(1, new Endpoint("host0", 6000), Collections.emptyList()));
+        servers.put(2, new ServerDescriptor(2, new Endpoint("host1", 6000), Collections.emptyList()));
+
+        assignment = policy.update(1, assignment, 3, servers);
+
+        /** Verify partition assignment of the servers.
+         *  Server 1 ====> P0
+         *  Server 2 ====> P1, P2
+         */
+        assertEquals(2, assignment.numEndpoints);
+        assertEquals(1, assignment.partitionsFor(1).size());
+        assertTrue(assignment.partitionsFor(1).contains(new PartitionInfo(0, 0)));
+        assertEquals(2, assignment.partitionsFor(2).size());
+        assertTrue(assignment.partitionsFor(2).contains(new PartitionInfo(1, 0)));
+        assertTrue(assignment.partitionsFor(2).contains(new PartitionInfo(2, 0)));
+
+        // Move P2 from Server 2 to Server 1 by making P2 as preferred partition of Server 1.
+        servers.put(1, new ServerDescriptor(1, new Endpoint("host0", 6000), Collections.singletonList(2)));
+        assignment = policy.update(2, assignment, 3, servers);
+
+        /** Verify partition assignment of the servers:
+         *  Server 1 ====> P0, P2
+         *  Server 2 ====> P1
+         */
+        assertEquals(2, assignment.numEndpoints);
+        assertEquals(2, assignment.partitionsFor(1).size());
+        assertTrue(assignment.partitionsFor(1).contains(new PartitionInfo(0, 0)));
+        assertTrue(assignment.partitionsFor(1).contains(new PartitionInfo(2, 1)));
+        assertEquals(1, assignment.partitionsFor(2).size());
+        assertTrue(assignment.partitionsFor(2).contains(new PartitionInfo(1, 0)));
+
+        // Move P2 from Server 1 to Server 2 by making P2 as preferred partition for Server 2.
+        servers.put(2, new ServerDescriptor(2, new Endpoint("host1", 6000), Collections.singletonList(2)));
+
+        /**
+         *  Note: At this point P2 is assigned as preferred partition for both Server 1 and Server 2.
+         *  Make sure to un-assign P2 as preferred partition of Server 1 if you want to successfully move P2 to
+         *  Server 2.
+         *  Otherwise, even after specifying P2 as a preferred partition of Server 2, P2 will get assigned to Server
+         *  1 as we assign the partitions to the servers in sequential order.
+         */
+        servers.put(1, new ServerDescriptor(1, new Endpoint("host0", 6000), Collections.emptyList()));
+        assignment = policy.update(3, assignment, 3, servers);
+
+        /** Verify partition assignment of the servers:
+         *  Server 1 ====> P0
+         *  Server 2 ====> P1, P2
+         */
+        assertEquals(2, assignment.numEndpoints);
+        assertEquals(1, assignment.partitionsFor(1).size());
+        assertTrue(assignment.partitionsFor(1).contains(new PartitionInfo(0, 0)));
+        assertEquals(2, assignment.partitionsFor(2).size());
+        assertTrue(assignment.partitionsFor(2).contains(new PartitionInfo(1, 0)));
+        assertTrue(assignment.partitionsFor(2).contains(new PartitionInfo(2, 2)));
+    }
+
 }


### PR DESCRIPTION
This commit contain changes to allow partitions to be moved between the servers.

The idea is to use preferred partitions. When Add/Remove preferred partition cli gets triggered, it will further call ClusterManagerImpl.manage(ManagedServer) method which will create new serverDescriptor (with updated preferred partitions list) for the given serverId. This change will then trigger the DynamicPartitionAssignmentPolicy to update the partition assignment of the servers. 

The logic of DynamicPartitionAssignmentPolicy is changed to handle partitions in this order:
1. preferred partitions of the server,
2. other partitions previously assigned to the server,
3. un-assigned partitions. 


Note: If same partition is assigned as the preferred partition to multiple servers (which might happen if remove preferred partition is not called), then the first server (we come across while sequential traversal) that has this preferred partition assigned will get the partition assigned to it. So, user has to make sure to call remove preferred partition whenever required. 
