### PR TITLE
Add timeout option for ZooKeeperClientImpl()

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -1,3 +1,3 @@
 group=com.wepay.zktools
 sourceCompatibility=1.8
-version=0.6.0
+version=0.7.0

--- a/src/main/java/com/wepay/zktools/zookeeper/internal/ZooKeeperClientImpl.java
+++ b/src/main/java/com/wepay/zktools/zookeeper/internal/ZooKeeperClientImpl.java
@@ -26,8 +26,11 @@ import java.util.Set;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.CompletionException;
 import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.ExecutionException;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
+import java.util.concurrent.TimeoutException;
+import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicReference;
 
 /**
@@ -55,6 +58,10 @@ public class ZooKeeperClientImpl implements ZooKeeperClient {
     private volatile boolean running = true;
 
     public ZooKeeperClientImpl(String connectString, int sessionTimeout) throws ZooKeeperClientException {
+        this(connectString, sessionTimeout, null);
+    }
+
+    public ZooKeeperClientImpl(String connectString, int sessionTimeout, Integer connectTimeout) throws ZooKeeperClientException {
         this.connectString = connectString;
         this.sessionTimeout = sessionTimeout;
         this.onConnectedWatcherManager = new ConnectionWatcherManager<>();
@@ -65,8 +72,12 @@ public class ZooKeeperClientImpl implements ZooKeeperClient {
         // Create a session
         try {
             CompletableFuture<ZooKeeperSessionImpl> future = ZooKeeperSessionImpl.createAsync(this);
-            sessionRef = new SessionRef(future.join());
-        } catch (CompletionException ex) {
+            if (connectTimeout == null) {
+                sessionRef = new SessionRef(future.join());
+            } else {
+                sessionRef = new SessionRef(future.get(connectTimeout, TimeUnit.SECONDS));
+            }
+        } catch (CompletionException | InterruptedException | ExecutionException | TimeoutException ex) {
             connectErrorRef.set(ex.getCause());
             throw new ZooKeeperClientException("connection failure", ex.getCause());
         }

--- a/src/main/java/com/wepay/zktools/zookeeper/internal/ZooKeeperClientImpl.java
+++ b/src/main/java/com/wepay/zktools/zookeeper/internal/ZooKeeperClientImpl.java
@@ -57,13 +57,23 @@ public class ZooKeeperClientImpl implements ZooKeeperClient {
 
     private volatile boolean running = true;
 
+    /**
+     * Constructor to create a ZooKeeperClientImpl instance.
+     * @param connectString comma separated host:port pairs, each corresponding to a zk server.
+     * @param sessionTimeout ZooKeeper session timeout in milliseconds.
+     * @throws ZooKeeperClientException exception to be thrown if connection failure.
+     * */
     public ZooKeeperClientImpl(String connectString, int sessionTimeout) throws ZooKeeperClientException {
         this(connectString, sessionTimeout, null);
     }
 
     /**
-     * Avoid directly use this constructor with a not-null connectTimeout parameter, unless you have to timeout this
-     * and exit retrying when there's no ZooKeeper running.
+     * Avoid directly use this constructor with a not-null connectTimeout parameter, unless you purposefully want to
+     * timeout the connection to ZooKeeper servers and exit retrying when there's no ZooKeeper running.
+     * @param connectString comma separated host:port pairs, each corresponding to a zk server.
+     * @param sessionTimeout ZooKeeper session timeout in milliseconds.
+     * @param connectTimeout timeout for connecting to ZooKeeper servers in milliseconds.
+     * @throws ZooKeeperClientException exception to be thrown if connection failure.
      * */
     public ZooKeeperClientImpl(String connectString, int sessionTimeout, Integer connectTimeout) throws ZooKeeperClientException {
         this.connectString = connectString;
@@ -79,7 +89,7 @@ public class ZooKeeperClientImpl implements ZooKeeperClient {
             if (connectTimeout == null) {
                 sessionRef = new SessionRef(future.join());
             } else {
-                sessionRef = new SessionRef(future.get(connectTimeout, TimeUnit.SECONDS));
+                sessionRef = new SessionRef(future.get(connectTimeout, TimeUnit.MILLISECONDS));
             }
         } catch (CompletionException | InterruptedException | ExecutionException | TimeoutException ex) {
             connectErrorRef.set(ex.getCause());

--- a/src/main/java/com/wepay/zktools/zookeeper/internal/ZooKeeperClientImpl.java
+++ b/src/main/java/com/wepay/zktools/zookeeper/internal/ZooKeeperClientImpl.java
@@ -61,6 +61,10 @@ public class ZooKeeperClientImpl implements ZooKeeperClient {
         this(connectString, sessionTimeout, null);
     }
 
+    /**
+     * Avoid directly use this constructor with a not-null connectTimeout parameter, unless you have to timeout this
+     * and exit retrying when there's no ZooKeeper running.
+     * */
     public ZooKeeperClientImpl(String connectString, int sessionTimeout, Integer connectTimeout) throws ZooKeeperClientException {
         this.connectString = connectString;
         this.sessionTimeout = sessionTimeout;

--- a/src/main/java/com/wepay/zktools/zookeeper/internal/ZooKeeperClientImpl.java
+++ b/src/main/java/com/wepay/zktools/zookeeper/internal/ZooKeeperClientImpl.java
@@ -68,8 +68,8 @@ public class ZooKeeperClientImpl implements ZooKeeperClient {
     }
 
     /**
-     * Avoid directly use this constructor with a not-null connectTimeout parameter, unless you purposefully want to
-     * timeout the connection to ZooKeeper servers and exit retrying when there's no ZooKeeper running.
+     * Constructor that provides the option to timeout the connection to ZooKeeper servers and exit retrying
+     * when ZooKeeper servers are not running.
      * @param connectString comma separated host:port pairs, each corresponding to a zk server.
      * @param sessionTimeout ZooKeeper session timeout in milliseconds.
      * @param connectTimeout timeout for connecting to ZooKeeper servers in milliseconds.

--- a/src/test/java/com/wepay/zktools/zookeeper/ZooKeeperClientTest.java
+++ b/src/test/java/com/wepay/zktools/zookeeper/ZooKeeperClientTest.java
@@ -101,7 +101,7 @@ public class ZooKeeperClientTest extends ZKTestUtils {
         try {
             String connectString = zooKeeperServerRunner.connectString();
 
-            new ZooKeeperClientImpl(connectString, 30000, 5);
+            new ZooKeeperClientImpl(connectString, 30000, 5000);
             fail("client unexpectedly created");
         } catch (ZooKeeperClientException ex) {
             // OK

--- a/src/test/java/com/wepay/zktools/zookeeper/ZooKeeperClientTest.java
+++ b/src/test/java/com/wepay/zktools/zookeeper/ZooKeeperClientTest.java
@@ -96,6 +96,22 @@ public class ZooKeeperClientTest extends ZKTestUtils {
     }
 
     @Test
+    public void testConnectTimeoutWhenZooKeeperNotRunning() throws Exception {
+        ZooKeeperServerRunner zooKeeperServerRunner = new ZooKeeperServerRunner(0);
+        try {
+            String connectString = zooKeeperServerRunner.connectString();
+
+            new ZooKeeperClientImpl(connectString, 30000, 5);
+            fail("client unexpectedly created");
+        } catch (ZooKeeperClientException ex) {
+            // OK
+        } finally {
+            zooKeeperServerRunner.stop();
+            zooKeeperServerRunner.clear();
+        }
+    }
+
+    @Test
     public void testSessionExpiration() throws Exception {
         ZooKeeperServerRunner zooKeeperServerRunner = new ZooKeeperServerRunner(0);
         try {


### PR DESCRIPTION
Add a constructor for ZooKeeperClientImpl so that applications can use it to timeout and exit retrying when they couldn't fetch ZooKeeper connection.