### PR TITLE
Modify DynamicPartitionAssignmentPolicy to acknowledge all preferred partitions

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -1,3 +1,3 @@
 group=com.wepay.zktools
 sourceCompatibility=1.8
-version=0.7.1
+version=0.7.2

--- a/src/main/java/com/wepay/zktools/clustermgr/internal/DynamicPartitionAssignmentPolicy.java
+++ b/src/main/java/com/wepay/zktools/clustermgr/internal/DynamicPartitionAssignmentPolicy.java
@@ -72,22 +72,16 @@ public class DynamicPartitionAssignmentPolicy implements PartitionAssignmentPoli
                     PartitionInfo oldInfo = unassignedPartitionInfoMap.get(partitionId);
                     if (oldInfo != null) {
                         Integer oldServerId = partitionToExistingServerMap.get(partitionId);
-                        if (partitions.size() < minNumPartitionsPerServer) {
-                            if (serverEntry.getKey().equals(oldServerId)) {
-                                partitions.add(oldInfo);
-                            } else {
-                                partitions.add(new PartitionInfo(partitionId, oldInfo.generation + 1));
-                            }
-                            numPartitionsToAssign--;
-                            unassignedPartitionInfoMap.remove(partitionId);
+
+                        if (serverEntry.getKey().equals(oldServerId)) {
+                            partitions.add(oldInfo);
                         } else {
-                            if (serverEntry.getKey().equals(oldServerId)) {
-                                partitions.add(oldInfo);
-                            } else {
-                                partitions.add(new PartitionInfo(partitionId, oldInfo.generation + 1));
-                            }
-                            numPartitionsToAssign--;
-                            unassignedPartitionInfoMap.remove(partitionId);
+                            partitions.add(new PartitionInfo(partitionId, oldInfo.generation + 1));
+                        }
+                        numPartitionsToAssign--;
+                        unassignedPartitionInfoMap.remove(partitionId);
+
+                        if (partitions.size() >= minNumPartitionsPerServer) {
                             remainingPartitions--;
                         }
                     }

--- a/src/test/java/com/wepay/zktools/clustermgr/internal/DynamicPartitionAssignmentPolicyTest.java
+++ b/src/test/java/com/wepay/zktools/clustermgr/internal/DynamicPartitionAssignmentPolicyTest.java
@@ -171,7 +171,7 @@ public class DynamicPartitionAssignmentPolicyTest {
         // Assign more than half of the partitions to server 2, all preferred partition assignment should be satisfied.
         servers.put(1, new ServerDescriptor(1, new Endpoint("host0", 6000), Collections.emptyList()));
         servers.put(2, new ServerDescriptor(2, new Endpoint("host1", 6000), Arrays.asList(0, 1, 3)));
-        assignment = policy.update(6, assignment, 4, servers);
+        assignment = policy.update(1, assignment, 4, servers);
 
         /** Verify partition assignment of the servers.
          *  Server 1: Partitions Assigned ====> P2;  Preferred Partitions ====> {}
@@ -193,7 +193,7 @@ public class DynamicPartitionAssignmentPolicyTest {
          *  Server 1: Partitions Assigned ====> P0, P1, P2;  Preferred Partitions ====> P0, P1, P2
          *  Server 2: Partitions Assigned ====> P3;  Preferred Partitions ====> P0, P1, P3
          * */
-        assignment = policy.update(6, assignment, 4, servers);
+        assignment = policy.update(2, assignment, 4, servers);
         assertEquals(2, assignment.numEndpoints);
         assertEquals(3, assignment.partitionsFor(1).size());
         assertTrue(assignment.partitionsFor(1).contains(new PartitionInfo(0, 2)));

--- a/src/test/java/com/wepay/zktools/clustermgr/internal/DynamicPartitionAssignmentPolicyTest.java
+++ b/src/test/java/com/wepay/zktools/clustermgr/internal/DynamicPartitionAssignmentPolicyTest.java
@@ -152,4 +152,55 @@ public class DynamicPartitionAssignmentPolicyTest {
         assertTrue(assignment.partitionsFor(2).contains(new PartitionInfo(2, 1)));
     }
 
+    @Test
+    public void testPreferredPartitions2() {
+        DynamicPartitionAssignmentPolicy policy = new DynamicPartitionAssignmentPolicy();
+
+        Map<Integer, List<PartitionInfo>> assignmentMap = new HashMap<>();
+        assignmentMap.put(1, Arrays.asList(
+            new PartitionInfo(0, 0),
+            new PartitionInfo(1, 0),
+            new PartitionInfo(2, 0),
+            new PartitionInfo(3, 0)
+            )
+        );
+
+        PartitionAssignment assignment = new PartitionAssignment(0, 4, assignmentMap);
+        Map<Integer, ServerDescriptor> servers = new HashMap<>();
+
+        // Assign more than half of the partitions to server 2, all preferred partition assignment should be satisfied.
+        servers.put(1, new ServerDescriptor(1, new Endpoint("host0", 6000), Collections.emptyList()));
+        servers.put(2, new ServerDescriptor(2, new Endpoint("host1", 6000), Arrays.asList(0, 1, 3)));
+        assignment = policy.update(6, assignment, 4, servers);
+
+        /** Verify partition assignment of the servers.
+         *  Server 1: Partitions Assigned ====> P2;  Preferred Partitions ====> {}
+         *  Server 2: Partitions Assigned ====> P0, P1, P3;  Preferred Partitions ====> P0, P1, P3
+         * */
+        assertEquals(2, assignment.numEndpoints);
+        assertEquals(1, assignment.partitionsFor(1).size());
+        assertTrue(assignment.partitionsFor(1).contains(new PartitionInfo(2, 0)));
+        assertEquals(3, assignment.partitionsFor(2).size());
+        assertTrue(assignment.partitionsFor(2).contains(new PartitionInfo(0, 1)));
+        assertTrue(assignment.partitionsFor(2).contains(new PartitionInfo(1, 1)));
+        assertTrue(assignment.partitionsFor(2).contains(new PartitionInfo(3, 1)));
+
+        // Assign more than half of the partitions to both servers, only the first server should be satisfied
+        servers.put(1, new ServerDescriptor(1, new Endpoint("host0", 6000), Arrays.asList(0, 1, 2)));
+        servers.put(2, new ServerDescriptor(2, new Endpoint("host1", 6000), Arrays.asList(0, 1, 3)));
+
+        /** Verify partition assignment of the servers.
+         *  Server 1: Partitions Assigned ====> P0, P1, P2;  Preferred Partitions ====> P0, P1, P2
+         *  Server 2: Partitions Assigned ====> P3;  Preferred Partitions ====> P0, P1, P3
+         * */
+        assignment = policy.update(6, assignment, 4, servers);
+        assertEquals(2, assignment.numEndpoints);
+        assertEquals(3, assignment.partitionsFor(1).size());
+        assertTrue(assignment.partitionsFor(1).contains(new PartitionInfo(0, 2)));
+        assertTrue(assignment.partitionsFor(1).contains(new PartitionInfo(1, 2)));
+        assertTrue(assignment.partitionsFor(1).contains(new PartitionInfo(2, 0)));
+        assertEquals(1, assignment.partitionsFor(2).size());
+        assertTrue(assignment.partitionsFor(2).contains(new PartitionInfo(3, 1)));
+    }
+
 }

--- a/src/test/java/com/wepay/zktools/clustermgr/internal/DynamicPartitionAssignmentPolicyTest.java
+++ b/src/test/java/com/wepay/zktools/clustermgr/internal/DynamicPartitionAssignmentPolicyTest.java
@@ -42,7 +42,7 @@ public class DynamicPartitionAssignmentPolicyTest {
         assertEquals(2, assignment.partitionsFor(2).size());
 
         servers.remove(0);
-        assignment = policy.update(1, assignment, 4, servers);
+        assignment = policy.update(2, assignment, 4, servers);
 
         assertEquals(2, assignment.numEndpoints);
         assertEquals(Utils.set(1, 2), assignment.serverIds());
@@ -50,14 +50,14 @@ public class DynamicPartitionAssignmentPolicyTest {
         assertEquals(2, assignment.partitionsFor(2).size());
 
         servers.remove(1);
-        assignment = policy.update(2, assignment, 4, servers);
+        assignment = policy.update(3, assignment, 4, servers);
 
         assertEquals(1, assignment.numEndpoints);
         assertEquals(Utils.set(2), assignment.serverIds());
         assertEquals(4, assignment.partitionsFor(2).size());
 
         servers.remove(2);
-        assignment = policy.update(2, assignment, 4, servers);
+        assignment = policy.update(-1, assignment, 4, servers);
 
         assertEquals(0, assignment.numEndpoints);
         assertTrue(assignment.serverIds().isEmpty());
@@ -90,7 +90,7 @@ public class DynamicPartitionAssignmentPolicyTest {
 
         // Make P2, P3 as preferred partition to server 1
         servers.put(1, new ServerDescriptor(1, new Endpoint("host0", 6000), Arrays.asList(2, 3)));
-        assignment = policy.update(2, assignment, 4, servers);
+        assignment = policy.update(1, assignment, 4, servers);
         /** Verify partition assignment of the servers. [Note: no change in assignment]
          *  Server 1: Partitions Assigned ====> P0, P1, P2, P3;  Preferred Partitions ====> P2, P3
          */
@@ -103,7 +103,7 @@ public class DynamicPartitionAssignmentPolicyTest {
 
         // Add server 2
         servers.put(2, new ServerDescriptor(2, new Endpoint("host1", 6000), Collections.emptyList()));
-        assignment = policy.update(3, assignment, 4, servers);
+        assignment = policy.update(2, assignment, 4, servers);
         /** Verify partition assignment of the servers. [Note: Change in assignment]
          *  Server 1: Partitions Assigned ====> P2, P3;  Preferred Partitions ====> P2, P3
          *  Server 2: Partitions Assigned ====> P0, P1;  Preferred Partitions ====> -
@@ -118,7 +118,7 @@ public class DynamicPartitionAssignmentPolicyTest {
 
         // Make P2 as preferred partition to Server 2
         servers.put(2, new ServerDescriptor(2, new Endpoint("host1", 6000), Collections.singletonList(2)));
-        assignment = policy.update(4, assignment, 4, servers);
+        assignment = policy.update(2, assignment, 4, servers);
         /** Verify partition assignment of the servers. [Note: No change in assignment]
          *  Server 1: Partitions Assigned ====> P2, P3;  Preferred Partitions ====> P2, P3
          *  Server 2: Partitions Assigned ====> P0, P1;  Preferred Partitions ====> P2
@@ -140,7 +140,7 @@ public class DynamicPartitionAssignmentPolicyTest {
          */
         // Un-assign P2 from server 1
         servers.put(1, new ServerDescriptor(1, new Endpoint("host0", 6000), Arrays.asList(3)));
-        assignment = policy.update(5, assignment, 4, servers);
+        assignment = policy.update(2, assignment, 4, servers);
         /** Verify partition assignment of the servers.
          *  Server 1: Partitions Assigned ====> (P0 or P1), P3;  Preferred Partitions ====> P3
          *  Server 2: Partitions Assigned ====> (P0 or P1), P2;  Preferred Partitions ====> P2
@@ -193,7 +193,7 @@ public class DynamicPartitionAssignmentPolicyTest {
          *  Server 1: Partitions Assigned ====> P0, P1, P2;  Preferred Partitions ====> P0, P1, P2
          *  Server 2: Partitions Assigned ====> P3;  Preferred Partitions ====> P0, P1, P3
          * */
-        assignment = policy.update(2, assignment, 4, servers);
+        assignment = policy.update(1, assignment, 4, servers);
         assertEquals(2, assignment.numEndpoints);
         assertEquals(3, assignment.partitionsFor(1).size());
         assertTrue(assignment.partitionsFor(1).contains(new PartitionInfo(0, 2)));


### PR DESCRIPTION
Currently, if the serverDescriptors asks for more than `( numPartitions / numServers) + 1` number of preferred partitions for one or more servers, at most only `( numPartitions / numServers) + 1` of them will be satisfied for each server by the DynamicPartitionAssignmentPolicy. This PR is to make the policy able to satisfy "all" preferred partitions requested and remove the above constraint.