### PR TITLE
ListCluster list changed from void to return String

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -1,3 +1,3 @@
 group=com.wepay.zktools
 sourceCompatibility=1.8
-version=0.7.2
+version=0.7.3


### PR DESCRIPTION
In Waltz/WaltzZooKeeperCli.java we have the need to access the content that is being printed out to std.out in ListCluster.java - list. Thus the modification of returning String first before sending everything to standard output.