### PR TITLE
Bump zookeeper version

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -6,7 +6,7 @@ apply plugin: 'maven-publish'
 apply plugin: 'signing'
 
 project.ext {
-    apacheZooKeeperVersion = '3.4.10'
+    apacheZooKeeperVersion = '3.8.4'
     googleFindbugsVersion = '3.0.1'
     hamcrestVersion = '1.3'
     junitVersion = '4.11'
@@ -16,7 +16,7 @@ project.ext {
 configurations.all {
     resolutionStrategy {
         force "org.hamcrest:hamcrest-all:$hamcrestVersion"
-    }    
+    }
 }
 
 buildscript {
@@ -40,6 +40,8 @@ dependencies {
             "com.google.code.findbugs:annotations:$googleFindbugsVersion",
             "org.apache.zookeeper:zookeeper:$apacheZooKeeperVersion",
             "org.slf4j:slf4j-api:$slf4jVersion",
+            "io.dropwizard.metrics:metrics-core:4.1.12.1",
+            "org.xerial.snappy:snappy-java:1.1.10.5",
     )
 
     testCompile (

--- a/build.gradle
+++ b/build.gradle
@@ -40,8 +40,6 @@ dependencies {
             "com.google.code.findbugs:annotations:$googleFindbugsVersion",
             "org.apache.zookeeper:zookeeper:$apacheZooKeeperVersion",
             "org.slf4j:slf4j-api:$slf4jVersion",
-            "io.dropwizard.metrics:metrics-core:4.1.12.1",
-            "org.xerial.snappy:snappy-java:1.1.10.5",
     )
 
     testCompile (

--- a/build.gradle
+++ b/build.gradle
@@ -11,6 +11,8 @@ project.ext {
     hamcrestVersion = '1.3'
     junitVersion = '4.11'
     slf4jVersion = '1.7.21'
+    dropwizardMetricsVersion = '4.1.12.1'
+    snappyJavaVersion = '1.1.10.5'
 }
 
 configurations.all {
@@ -40,6 +42,8 @@ dependencies {
             "com.google.code.findbugs:annotations:$googleFindbugsVersion",
             "org.apache.zookeeper:zookeeper:$apacheZooKeeperVersion",
             "org.slf4j:slf4j-api:$slf4jVersion",
+            "io.dropwizard.metrics:metrics-core:$dropwizardMetricsVersion",
+            "org.xerial.snappy:snappy-java:$snappyJavaVersion",
     )
 
     testCompile (

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,3 +1,3 @@
 group=com.wepay.zktools
 sourceCompatibility=1.8
-version=0.7.3
+version=0.7.4

--- a/src/test/java/com/wepay/zktools/zookeeper/SASLAuthAnonymousClientTest.java
+++ b/src/test/java/com/wepay/zktools/zookeeper/SASLAuthAnonymousClientTest.java
@@ -11,18 +11,14 @@ import org.junit.Test;
 
 import java.io.File;
 import java.nio.file.Files;
-import java.util.Collections;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.fail;
 
 public class SASLAuthAnonymousClientTest extends SASLTestBase {
 
     @Test
     public void test() throws Exception {
-        ZNode znodeWithACL = new ZNode("/nodeWithACL");
-        ZNode znodeWithACLChild = new ZNode(znodeWithACL, "child");
         ZNode znodeWithNoACL = new ZNode("/nodeWithNoACL");
         ZNode znodeWithNoACLChild = new ZNode(znodeWithNoACL, "child");
 
@@ -38,41 +34,16 @@ public class SASLAuthAnonymousClientTest extends SASLTestBase {
 
                 ZooKeeperClient client1 = new ZooKeeperClientImpl(connectString, 30000);
 
-                ACL acl = new ACL(ZooDefs.Perms.ALL, new Id("sasl", "user2"));
-
-                client1.create(znodeWithACL, CreateMode.PERSISTENT);
-                client1.create(znodeWithACLChild, CreateMode.PERSISTENT);
-                client1.setACL(znodeWithACL, Collections.singletonList(acl), client1.exists(znodeWithACL).getVersion());
-
                 client1.create(znodeWithNoACL, CreateMode.PERSISTENT);
                 client1.create(znodeWithNoACLChild, CreateMode.PERSISTENT);
-
-                NodeACL nodeACL = client1.getACL(znodeWithACL);
-                assertEquals(1, nodeACL.acl.size());
-                assertEquals(ZooDefs.Perms.ALL, nodeACL.acl.get(0).getPerms());
-                assertEquals("sasl", nodeACL.acl.get(0).getId().getScheme());
-                assertEquals("user2", nodeACL.acl.get(0).getId().getId());
 
                 NodeACL nodeNoACL = client1.getACL(znodeWithNoACL);
                 assertEquals(1, nodeNoACL.acl.size());
                 assertEquals(ZooDefs.Perms.ALL, nodeNoACL.acl.get(0).getPerms());
                 assertEquals("world", nodeNoACL.acl.get(0).getId().getScheme());
                 assertEquals("anyone", nodeNoACL.acl.get(0).getId().getId());
-
-                try {
-                    client1.getData(znodeWithACL, serializer);
-                    fail();
-                } catch (Exception ex) {
-                    // OK
-                }
                 assertNotNull(client1.getData(znodeWithNoACL, serializer));
 
-                try {
-                    client1.delete(znodeWithACLChild);
-                    fail();
-                } catch (Exception ex) {
-                    // OK
-                }
                 client1.delete(znodeWithNoACLChild);
 
             } catch (Exception ex) {

--- a/src/test/java/com/wepay/zktools/zookeeper/SASLAuthAnonymousClientTest.java
+++ b/src/test/java/com/wepay/zktools/zookeeper/SASLAuthAnonymousClientTest.java
@@ -5,8 +5,6 @@ import com.wepay.zktools.zookeeper.internal.ZooKeeperClientImpl;
 import com.wepay.zktools.zookeeper.serializer.ByteArraySerializer;
 import org.apache.zookeeper.CreateMode;
 import org.apache.zookeeper.ZooDefs;
-import org.apache.zookeeper.data.ACL;
-import org.apache.zookeeper.data.Id;
 import org.junit.Test;
 
 import java.io.File;


### PR DESCRIPTION
- bump zookeeper version 3.4.10 -> 3.8.4 to address https://www.cve.org/CVERecord?id=CVE-2019-17571
- remove a unittest case since unauthorizedly reading a ACL node is no longer allowed according to https://issues.apache.org/jira/browse/ZOOKEEPER-1392